### PR TITLE
Do not append to test scripts.

### DIFF
--- a/comanage-registry/docker-comanage-entrypoint
+++ b/comanage-registry/docker-comanage-entrypoint
@@ -119,7 +119,7 @@ fi
 # Loop until we are able to open a connection to the database.
 DATABASE_TEST_SCRIPT="$COMANAGE_REGISTRY_DIR/app/Console/Command/DatabaseTestShell.php"
 
-cat >> $DATABASE_TEST_SCRIPT <<"EOF"
+cat > $DATABASE_TEST_SCRIPT <<"EOF"
 <?php
 
 App::import('Model', 'ConnectionManager');
@@ -153,7 +153,7 @@ popd > "$OUTPUT" 2>&1
 # we create an ephemeral CakePHP script to tell us.
 SETUP_ALREADY_SCRIPT="$COMANAGE_REGISTRY_DIR/app/Console/Command/SetupAlreadyShell.php"
 
-cat >> $SETUP_ALREADY_SCRIPT <<"EOF"
+cat > $SETUP_ALREADY_SCRIPT <<"EOF"
 <?php
 
 class SetupAlreadyShell extends AppShell {


### PR DESCRIPTION
If the database is not available and the container exits before the test scripts are deleted, future invocations of the scripts will not succeed even if the database is available because they are appended to.