### PR TITLE
Fixed missing colon in yaml

### DIFF
--- a/docs/mod-auth-openidc-mariadb.md
+++ b/docs/mod-auth-openidc-mariadb.md
@@ -219,9 +219,9 @@ services:
 secrets:
     comanage_registry_database_user_password:
         external: true
-    mariadb_root_password
+    mariadb_root_password:
         external: true
-    mariadb_password
+    mariadb_password:
         external: true
     https_cert_file:
         external: true

--- a/docs/shibboleth-sp-mariadb.md
+++ b/docs/shibboleth-sp-mariadb.md
@@ -233,9 +233,9 @@ services:
 secrets:
     comanage_registry_database_user_password:
         external: true
-    mariadb_root_password
+    mariadb_root_password:
         external: true
-    mariadb_password
+    mariadb_password:
         external: true
     shibboleth_sp_encrypt_cert:
         external: true


### PR DESCRIPTION
Some YAML in the documentation is missing a colon.