### PR TITLE
[DocFix] Correct environment variables for tags in build instructions

### DIFF
--- a/docs/shibboleth-sp-mariadb.md
+++ b/docs/shibboleth-sp-mariadb.md
@@ -85,6 +85,7 @@ to be the version of the image you are about to build:
 
 ```
 export COMANAGE_REGISTRY_SHIBBOLETH_SP_IMAGE_VERSION=1
+export COMANAGE_REGISTRY_SHIBBOLETH_SP_VERSION=3.2.1
 ```
 
 * Build an image for COmanage Registry that uses the Shibboleth SP
@@ -97,6 +98,7 @@ docker build \
     --build-arg COMANAGE_REGISTRY_VERSION=${COMANAGE_REGISTRY_VERSION} \
     --build-arg COMANAGE_REGISTRY_BASE_IMAGE_VERSION=${COMANAGE_REGISTRY_BASE_IMAGE_VERSION} \
     --build-arg COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION=${COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION} \
+    --build-arg COMANAGE_REGISTRY_SHIBBOLETH_SP_VERSION=${COMANAGE_REGISTRY_SHIBBOLETH_SP_VERSION} \
     -t comanage-registry:$TAG .
 popd
 ```

--- a/docs/shibboleth-sp-mariadb.md
+++ b/docs/shibboleth-sp-mariadb.md
@@ -74,7 +74,7 @@ export COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION=1
 
 ```
 pushd comanage-registry-shibboleth-sp-base
-TAG="${COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION}"
+TAG=${COMANAGE_REGISTRY_SHIBBOLETH_SP_VERSION}-${COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION}
 docker build \
     -t comanage-registry-shibboleth-sp-base:$TAG . 
 popd


### PR DESCRIPTION
Following the current instructions gives the error below. I believe this is because:

 - `comanage-registry-shibboleth-sp-base` only has a tag, not a version:tag
 - The Docker file references an environment variable that the documentation does not set.

Patch should fix these.

```sh
Successfully tagged comanage-registry-shibboleth-sp-base:1
popd
~/projects/ce/ce-it-infrastructure/roster/comanage-registry-docker ~/projects/ce/ce-it-infrastructure/roster

export COMANAGE_REGISTRY_SHIBBOLETH_SP_IMAGE_VERSION=1

pushd comanage-registry-shibboleth-sp
~/projects/ce/ce-it-infrastructure/roster/comanage-registry-docker/comanage-registry-shibboleth-sp ~/projects/ce/ce-it-infrastructure/roster/comanage-registry-docker ~/projects/ce/ce-it-infrastructure/roster
TAG="${COMANAGE_REGISTRY_VERSION}-shibboleth-sp-${COMANAGE_REGISTRY_SHIBBOLETH_SP_IMAGE_VERSION}"
docker build \
    --build-arg COMANAGE_REGISTRY_VERSION=${COMANAGE_REGISTRY_VERSION} \
    --build-arg COMANAGE_REGISTRY_BASE_IMAGE_VERSION=${COMANAGE_REGISTRY_BASE_IMAGE_VERSION} \
    --build-arg COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION=${COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION} \
    -t comanage-registry:$TAG .
Sending build context to Docker daemon  12.29kB
Step 1/25 : ARG COMANAGE_REGISTRY_VERSION=develop
Step 2/25 : ARG COMANAGE_REGISTRY_BASE_IMAGE_VERSION=1
Step 3/25 : ARG COMANAGE_REGISTRY_SHIBBOLETH_SP_VERSION="3.0.3"
Step 4/25 : ARG COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION=1
Step 5/25 : FROM comanage-registry-shibboleth-sp-base:${COMANAGE_REGISTRY_SHIBBOLETH_SP_VERSION}-${COMANAGE_REGISTRY_SHIBBOLETH_SP_BASE_IMAGE_VERSION} AS shib-base
pull access denied for comanage-registry-shibboleth-sp-base, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```