### PR TITLE
Fix permission on patched code

### DIFF
--- a/comanage-registry-mailman/core/Dockerfile
+++ b/comanage-registry-mailman/core/Dockerfile
@@ -57,6 +57,7 @@ ENV MAILMAN_CONFIG_FILE /etc/mailman.cfg
 # are accepted upstream.
 COPY addresses.py /usr/local/lib/python3.6/site-packages/mailman/rest/addresses.py
 COPY users.py /usr/local/lib/python3.6/site-packages/mailman/rest/users.py
+RUN chmod 644 /usr/local/lib/python3.6/site-packages/mailman/rest/addresses.py /usr/local/lib/python3.6/site-packages/mailman/rest/users.py
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["master", "--force"]


### PR DESCRIPTION
`COPY` is putting these files in place with perms 640 and owned by root, but the user mailman needs to read them. This generates the error below. Fix is to make them world readable.

```
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    | Postgres is up - continuing
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    | HYPERKITTY_URL not set, using the default value of http://mailman-web:8000/hyperkitty
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    | Traceback (most recent call last):
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/bin/runner", line 10, in <module>
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     sys.exit(main())
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     return self.main(*args, **kwargs)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/click/core.py", line 717, in main
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     rv = self.invoke(ctx)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     return ctx.invoke(self.callback, **ctx.params)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     return callback(*args, **kwargs)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     return f(get_current_context(), *args, **kwargs)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/mailman/bin/runner.py", line 184, in main
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     runner = make_runner(*runner_spec, once=once)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/mailman/bin/runner.py", line 55, in make_runner
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     runner_class = find_name(class_path)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/mailman/utilities/modules.py", line 52, in find_name
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     module = import_module(module_path)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/importlib/__init__.py", line 126, in import_module
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     return _bootstrap._gcd_import(name[level:], package, level)
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap>", line 994, in _gcd_import
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap>", line 971, in _find_and_load
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap_external>", line 678, in exec_module
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/mailman/runners/rest.py", line 27, in <module>
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     from mailman.rest.wsgiapp import make_server
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/mailman/rest/wsgiapp.py", line 28, in <module>
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     from mailman.rest.root import Root
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "/usr/local/lib/python3.6/site-packages/mailman/rest/root.py", line 26, in <module>
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |     from mailman.rest.addresses import AllAddresses, AnAddress
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap>", line 971, in _find_and_load
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap_external>", line 674, in exec_module
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap_external>", line 780, in get_code
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    |   File "<frozen importlib._bootstrap_external>", line 832, in get_data
mailman_mailman-core.1.l59bw0mxwv8t@sugwg-scitokens.phy.syr.edu    | PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.6/site-packages/mailman/rest/addresses.py'
```