### PR TITLE
Allow the use of a separate ca chain file

### DIFF
--- a/comanage-registry-base/comanage_utils.sh
+++ b/comanage-registry-base/comanage_utils.sh
@@ -390,7 +390,7 @@ function comanage_utils::prepare_https_cert_key() {
         chown "${web_user}" "${chain_path}"
         chmod 0644 "${chain_path}"
         sed -i -e 's/^#SSLCertificateChainFile/SSLCertificateChainFile/' ${ssl_conf_file}
-        sed -i -e "s/%%CHAIN_PATH%%/${chain_path}/" ${ssl_conf_file}
+        sed -i -e "s+%%CHAIN_PATH%%+${chain_path}+" ${ssl_conf_file}
         echo "Copied HTTPS CA Chain file ${HTTPS_CHAIN_FILE} to ${chain_path}" > "$OUTPUT"
         echo "Set ownership of ${chain_path} to ${web_user}" > "$OUTPUT"
         echo "Configured apache to use SSLCertificateChainFile=${chain_path}" > "$OUTPUT"

--- a/comanage-registry-base/comanage_utils.sh
+++ b/comanage-registry-base/comanage_utils.sh
@@ -389,8 +389,8 @@ function comanage_utils::prepare_https_cert_key() {
         cp "${HTTPS_CHAIN_FILE}" "${chain_path}"
         chown "${web_user}" "${chain_path}"
         chmod 0644 "${chain_path}"
-        sed -i -e 's/^#SSLCertificateChainFile/SSLCertificateChainFile' ${ssl_config_file}
-        sed -i -e "s/%%CHAIN_PATH%%/${chain_path}" ${ssl_config_file}
+        sed -i -e 's/^#SSLCertificateChainFile/SSLCertificateChainFile/' ${ssl_conf_file}
+        sed -i -e "s/%%CHAIN_PATH%%/${chain_path}/" ${ssl_conf_file}
         echo "Copied HTTPS CA Chain file ${HTTPS_CHAIN_FILE} to ${chain_path}" > "$OUTPUT"
         echo "Set ownership of ${chain_path} to ${web_user}" > "$OUTPUT"
         echo "Configured apache to use SSLCertificateChainFile=${chain_path}" > "$OUTPUT"

--- a/comanage-registry-basic-auth/000-comanage.conf
+++ b/comanage-registry-basic-auth/000-comanage.conf
@@ -25,6 +25,7 @@ Include apache-include-virtual-host-port443-base
 
 SSLCertificateFile /etc/apache2/cert.pem
 SSLCertificateKeyFile /etc/apache2/privkey.pem
+#SSLCertificateChainFile %%CHAIN_PATH%%
 
 ErrorLog ${APACHE_LOG_DIR}/error.log
 CustomLog ${APACHE_LOG_DIR}/access.log combined

--- a/comanage-registry-basic-auth/README.md
+++ b/comanage-registry-basic-auth/README.md
@@ -120,8 +120,8 @@ stderr of the container.
 
 ## HTTPS Configuration
 
-See the section on environment variables and the `HTTPS_CERT_FILE` and
-`HTTPS_PRIVKEY_FILE` variables.
+See the section on environment variables and the `HTTPS_CERT_FILE`,
+`HTTPS_PRIVKEY_FILE`, and `HTTPS_CHAIN_FILE` variables.
 
 Additionally you may bind mount or COPY in an X.509 certificate file (containing the CA signing certificate(s), if any)
 and associated private key file. For example

--- a/comanage-registry-internet2-tier/000-comanage.conf
+++ b/comanage-registry-internet2-tier/000-comanage.conf
@@ -30,6 +30,7 @@ Include apache-include-virtual-host-port443-base
 
 SSLCertificateFile /etc/httpd/cert.pem
 SSLCertificateKeyFile /etc/httpd/privkey.pem
+#SSLCertificateChainFile %%CHAIN_PATH%%
 
 PassEnv ENV
 PassEnv USERTOKEN

--- a/comanage-registry-internet2-tier/README.md
+++ b/comanage-registry-internet2-tier/README.md
@@ -147,8 +147,8 @@ The logging configuration meets version 1 of the
 
 ## HTTPS Configuration
 
-See the section on environment variables and the `HTTPS_CERT_FILE` and
-`HTTPS_PRIVKEY_FILE` variables.
+See the section on environment variables and the `HTTPS_CERT_FILE`,
+`HTTPS_PRIVKEY_FILE`, and `HTTPS_CHAIN_FILE` variables.
 
 Additionally you may bind mount or COPY in an X.509 certificate file (containing the CA signing certificate(s), if any)
 and associated private key file. For example

--- a/comanage-registry-mailman/apache-shib/httpd.conf
+++ b/comanage-registry-mailman/apache-shib/httpd.conf
@@ -118,6 +118,7 @@ TransferLog /proc/self/fd/1
 SSLEngine on
 SSLCertificateFile "/usr/local/apache2/conf/server.crt"
 SSLCertificateKeyFile "/usr/local/apache2/conf/server.key"
+#SSLCertificateChainFile "/usr/local/apache2/conf/ca-chain.crt"
 
 BrowserMatch "MSIE [2-5]" \
          nokeepalive ssl-unclean-shutdown \

--- a/comanage-registry-mailman/apache-shib/start.sh
+++ b/comanage-registry-mailman/apache-shib/start.sh
@@ -55,6 +55,13 @@ if [ -n "${HTTPS_CERT_FILE}" ] && [ -n "${HTTPS_KEY_FILE}" ]; then
     chmod 600 /usr/local/apache2/conf/server.key
 fi
 
+# Copy HTTPS chain file into place.
+if [ -n "${HTTPS_CHAIN_FILE}" ]; then
+    cp "${HTTPS_CHAIN_FILE}" /usr/local/apache2/conf/ca-chain.crt
+    chmod 644 /usr/local/apache2/conf/ca-chain.crt
+    sed -i -e 's/^#SSLCertificateChainFile/SSLCertificateChainFile' /usr/local/apache2/conf/httpd.conf
+fi
+
 # Wait for the mailman core container to be ready.
 until nc -z -w 1 "${MAILMAN_CORE_HOST}" "${MAILMAN_CORE_PORT}"
 do

--- a/comanage-registry-mod-auth-openidc/000-comanage.conf
+++ b/comanage-registry-mod-auth-openidc/000-comanage.conf
@@ -25,6 +25,7 @@ Include apache-include-virtual-host-port443-base
 
 SSLCertificateFile /etc/apache2/cert.pem
 SSLCertificateKeyFile /etc/apache2/privkey.pem
+#SSLCertificateChainFile %%CHAIN_PATH%%
 
 ErrorLog ${APACHE_LOG_DIR}/error.log
 CustomLog ${APACHE_LOG_DIR}/access.log combined

--- a/comanage-registry-mod-auth-openidc/README.md
+++ b/comanage-registry-mod-auth-openidc/README.md
@@ -139,8 +139,8 @@ stderr of the container.
 
 ## HTTPS Configuration
 
-See the section on environment variables and the `HTTPS_CERT_FILE` and
-`HTTPS_PRIVKEY_FILE` variables.
+See the section on environment variables and the `HTTPS_CERT_FILE`,
+`HTTPS_PRIVKEY_FILE`, and `HTTPS_CHAIN_FILE` variables.
 
 Additionally you may bind mount or COPY in an X.509 certificate file (containing the CA signing certificate(s), if any)
 and associated private key file. For example

--- a/comanage-registry-shibboleth-sp/000-comanage.conf
+++ b/comanage-registry-shibboleth-sp/000-comanage.conf
@@ -25,6 +25,7 @@ Include apache-include-virtual-host-port443-base
 
 SSLCertificateFile /etc/apache2/cert.pem
 SSLCertificateKeyFile /etc/apache2/privkey.pem
+#SSLCertificateChainFile %%CHAIN_PATH%%
 
 ErrorLog ${APACHE_LOG_DIR}/error.log
 CustomLog ${APACHE_LOG_DIR}/access.log combined

--- a/comanage-registry-shibboleth-sp/README.md
+++ b/comanage-registry-shibboleth-sp/README.md
@@ -125,8 +125,8 @@ stderr of the container.
 
 ## HTTPS Configuration
 
-See the section on environment variables and the `HTTPS_CERT_FILE` and
-`HTTPS_PRIVKEY_FILE` variables.
+See the section on environment variables and the `HTTPS_CERT_FILE`,
+`HTTPS_PRIVKEY_FILE`, and `HTTPS_CHAIN_FILE` variables.
 
 Additionally you may bind mount or COPY in an X.509 certificate file (containing the CA signing certificate(s), if any)
 and associated private key file. For example

--- a/docs/comanage-registry-common-environment-variables.md
+++ b/docs/comanage-registry-common-environment-variables.md
@@ -209,6 +209,14 @@ edited directly.
 * Example: /run/secrets/https_privkey_file
 * Note: The path is relative to the running container.
 
+```HTTPS_CHAIN_FILE```
+
+* Description: path to file containing x509 certificate signing chain for HTTPS, if not specified then `HTTPS_CERT_FILE` much contain a full signing chain for the certificate.
+* Required: no
+* Default: none
+* Example: /run/secrets/https_chain_file
+* Note: The path is relative to the running container.
+
 
 ```SERVER_NAME```
 


### PR DESCRIPTION
This pull request implements a `HTTPS_CHAIN_FILE` environment variable that (optionally) allows the user to specify a CA chain. If this is not given then `HTTPS_CERT_FILE` must contain the full CA chain as well as the certificate, as before.

The motivation is because https://github.com/linuxserver/docker-letsencrypt generates separate chain and cert files.