### PR TITLE
use MM_HOSTNAME to set hostname and lmtp_host

### DIFF
--- a/comanage-registry-mailman/core/docker-entrypoint.sh
+++ b/comanage-registry-mailman/core/docker-entrypoint.sh
@@ -157,14 +157,12 @@ then
     wait_for_mysql
 fi
 
-CONTAINER_IP=`hostname -i`
-
 # Generate a basic mailman.cfg.
 cat >> /etc/mailman.cfg <<EOF
 [mta]
 incoming: mailman.mta.postfix.LMTP
 outgoing: mailman.mta.deliver.deliver
-lmtp_host: $CONTAINER_IP
+lmtp_host: $MM_HOSTNAME
 lmtp_port: 8024
 smtp_host: $SMTP_HOST
 smtp_port: $SMTP_PORT
@@ -174,7 +172,7 @@ configuration: /etc/postfix-mailman.cfg
 sleep_time: 10s
 
 [webservice]
-hostname: $CONTAINER_IP
+hostname: $MM_HOSTNAME
 port: $MAILMAN_REST_PORT
 admin_user: $MAILMAN_REST_USER
 admin_pass: $MAILMAN_REST_PASSWORD


### PR DESCRIPTION
The mailman core `docker-entrypoint.sh` looks for a variable name `MM_HOSTNAME` and sets it to `hostname -i` if it is empty. However, the `mailman.cfg` file then ignores `MM_HOSTNAME` and sets `lmtp_host` and `hostname` from `$CONTAINER_IP` which is always set with a `hostname -i`.

This pull request fixes the `mailman.cfg` to use `MM_HOSTNAME` so it can be `hostname -i` can be overridden. I need to do this, as on my docker setup `hostname -i` returns two IP addresses, which seems to confuse mailman:
```
[webservice]
hostname: 192.168.102.4 172.30.102.5
port: 8001
```
